### PR TITLE
add FOV filter to pepperl API/Interface

### DIFF
--- a/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/http_command_interface.h
+++ b/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/http_command_interface.h
@@ -57,7 +57,7 @@ public:
     //! Request TCP handle
     //! @param start_angle Set start angle for scans in the range [0,3600000] (1/10000°)
     //! @returns A valid HandleInfo on success, an empty boost::optional<HandleInfo> container otherwise
-    boost::optional<HandleInfo> requestHandleTCP(int start_angle=-1800000);
+    boost::optional<HandleInfo> requestHandleTCP(int start_angle=-1800000, uint32_t max_num_points_scan=0U);
 
     //! Request UDP handle
     //! @param port Set UDP port where scanner data should be sent to

--- a/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/r2000_driver.h
+++ b/pepperl_fuchs_r2000/include/pepperl_fuchs_r2000/r2000_driver.h
@@ -66,7 +66,7 @@ public:
 
     //! Start capturing laserdata: Requests a handle and begin retrieving data from the scanner
     //! @returns True in case of success, False otherwise
-    bool startCapturingTCP();
+    bool startCapturingTCP(int start_angle, uint32_t max_num_points_scan);
 
     //! Start capturing laserdata: Requests a handle and begin retrieving data from the scanner
     //! @returns True in case of success, False otherwise

--- a/pepperl_fuchs_r2000/src/driver/http_command_interface.cpp
+++ b/pepperl_fuchs_r2000/src/driver/http_command_interface.cpp
@@ -275,12 +275,13 @@ std::vector< std::string > HttpCommandInterface::getParameterList()
 }
 
 //-----------------------------------------------------------------------------
-boost::optional<HandleInfo> HttpCommandInterface::requestHandleTCP(int start_angle)
+boost::optional<HandleInfo> HttpCommandInterface::requestHandleTCP(int start_angle, uint32_t max_num_points_scan)
 {
     // Prepare HTTP request
     std::map< std::string, std::string > params;
     params["packet_type"] = "C";
     params["start_angle"] = std::to_string(start_angle);
+    params["max_num_points_scan"] = std::to_string(max_num_points_scan);
 
     // Request handle via HTTP/JSON request/response
     if( !sendHttpCommand("request_handle_tcp", params) || !checkErrorCode() )

--- a/pepperl_fuchs_r2000/src/driver/r2000_driver.cpp
+++ b/pepperl_fuchs_r2000/src/driver/r2000_driver.cpp
@@ -75,12 +75,12 @@ R2000Driver::~R2000Driver()
 }
 
 //-----------------------------------------------------------------------------
-bool R2000Driver::startCapturingTCP()
+bool R2000Driver::startCapturingTCP(int start_angle, uint32_t max_num_points_scan)
 {
     if( !checkConnection() )
         return false;
 
-    handle_info_ = command_interface_->requestHandleTCP();
+    handle_info_ = command_interface_->requestHandleTCP(start_angle, max_num_points_scan);
     if( !handle_info_ )
         return false;
 

--- a/pepperl_fuchs_r2000/src/rosnode/r2000_node.h
+++ b/pepperl_fuchs_r2000/src/rosnode/r2000_node.h
@@ -79,6 +79,12 @@ private:
     //! samples_per_scan parameter
     int samples_per_scan_;
 
+    //! start_angle parameter
+    double start_angle_;
+
+    //! stop_angle parameter
+    double stop_angle_;
+
     //! Pointer to driver
     R2000Driver* driver_;
 };


### PR DESCRIPTION
I had to change the Pepperl Driver code to allow for sending through a FOV filter.
This also means there are 2 new parameters to the ROS node.

These changes should mirror the work done for the ASI ROS2 P+F driver.